### PR TITLE
トップページの修正

### DIFF
--- a/front/components/generalButton.tsx
+++ b/front/components/generalButton.tsx
@@ -1,17 +1,15 @@
 import Link from 'next/link'
-import router from 'next/router'
-import Questions from '../pages/question'
 
 type GeneralButton = {
   readonly text: string
-  readonly content: 'question' | 'register'
+  readonly language: 'france' | 'russia'
 }
 const GeneralButton = (generalButton: GeneralButton) => {
-  const path = `../${generalButton.content}`
+  const path = `../register/${generalButton.language}`
   return (
     <div>
       <Link href={path}>
-        <div className="m-5 rounded bg-orange-500 p-3 pr-4 pl-4 text-white hover:bg-orange-400">
+        <div className="m-5 rounded bg-orange-500 p-4 pr-6 pl-6 text-xl text-white hover:bg-orange-400">
           {generalButton.text}
         </div>
       </Link>

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -35,17 +35,8 @@ const Home: NextPage = () => {
               問題を解く
             </p>
             <div className="flex justify-center">
-              <GeneralButton text="フランス語" content="question" />
-              <GeneralButton text="ロシア語" content="question" />
-            </div>
-          </div>
-          <div className="pt-2 pb-2 lg:pt-4">
-            <p className="p-3 text-[1.75rem] text-orange-900 sm:text-2xl md:text-3xl lg:text-4xl">
-              問題を登録する
-            </p>
-            <div className="flex justify-center">
-              <GeneralButton text="フランス語" content="register" />
-              <GeneralButton text="ロシア語" content="register" />
+              <GeneralButton text="フランス語" language="france" />
+              <GeneralButton text="ロシア語" language="russia" />
             </div>
           </div>
         </div>

--- a/front/pages/question/france.tsx
+++ b/front/pages/question/france.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import Header from '../../components/header'
+
+const Questions = () => {
+  const title = '問題'
+  return (
+    <>
+      <Header title={title}>
+        <h1>React</h1>
+      </Header>
+      <Link href="/">
+        <a>トップページに戻る &gt;&gt;</a>
+      </Link>
+    </>
+  )
+}
+
+export default Questions

--- a/front/pages/question/russia.tsx
+++ b/front/pages/question/russia.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import Header from '../../components/header'
+
+const Questions = () => {
+  const title = '問題'
+  return (
+    <>
+      <Header title={title}>
+        <h1>React</h1>
+      </Header>
+      <Link href="/">
+        <a>トップページに戻る &gt;&gt;</a>
+      </Link>
+    </>
+  )
+}
+
+export default Questions

--- a/front/pages/register/france.tsx
+++ b/front/pages/register/france.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import Header from '../components/header'
+import Header from '../../components/header'
 
 const Register = () => {
   const title = '問題を登録する'

--- a/front/pages/register/russia.tsx
+++ b/front/pages/register/russia.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link'
-import Header from '../components/header'
+import Header from '../../components/header'
 
-const Questions = () => {
-  const title = '問題'
+const Register = () => {
+  const title = '問題を登録する'
   return (
     <>
       <Header title={title}>
@@ -15,4 +15,4 @@ const Questions = () => {
   )
 }
 
-export default Questions
+export default Register


### PR DESCRIPTION
問題を解くボタンと登録するボタンを分けて作ってしまっていたが、問題を解くボタンだけに修正した
問題を解くボタンを押すと、言語ごとに単語登録ページに遷移し、登録し終わったら問題を解く仕様にした。